### PR TITLE
Fix: Folder counter stuck at 0 due to missing flash erase in save_dword()

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
             cd arm_segger_embedded_studio_v622a_linux_x64/bin
             ./emBuild -config "Debug" ${{ github.workspace }}//Burnmaster-Firmware/CartReaderApp/GDCartReader.emProject
           
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Burnmaster-Firmware
           path: ${{ github.workspace }}//Burnmaster-Firmware/CartReaderApp/Output/Debug/Exe/GDCartReader.bin

--- a/CartReaderApp/flashparam.c
+++ b/CartReaderApp/flashparam.c
@@ -7,10 +7,10 @@
 
 void save_dword(uint32_t data)
 {
-  //
   fmc_unlock();
+  fmc_page_erase(FMC_WRITE_START_ADDR);
+  fmc_flag_clear(FMC_FLAG_BANK0_END | FMC_FLAG_BANK0_WPERR | FMC_FLAG_BANK0_PGERR);
   fmc_word_program(FMC_WRITE_START_ADDR, data);
-  //lock the main FMC after the program operation */
   fmc_lock();
 }
 


### PR DESCRIPTION
## Problem

The folder counter at `0x0803FC00` stays stuck at `0` across all operations and reboots. Every Read ROM and Read Save operation writes to folder `0/`, silently overwriting the previous backup.

MCU flash bits can only transition `1→0` without erase. `save_dword()` wrote directly to flash without a prior sector erase, so all writes after the first silently failed.

Lines 32–43 of `flashparam.c` contain a near-correct erase sequence as commented-out code, but it uses flag constants (`FMC_FLAG_END`, `FMC_FLAG_WPERR`, `FMC_FLAG_PGERR`) that don't exist in the bundled GD32F10x library — these names appear to come from STM32 HAL. The correct bank-qualified constants are `FMC_FLAG_BANK0_*`. This likely explains why the erase code never made it out of the comment block: it never compiled.

## Changes

**Commit 1 — `Fix: Add missing flash erase before counter write`**

Adds the missing `fmc_page_erase()` before `fmc_word_program()` in `CartReaderApp/flashparam.c`, using the correct `FMC_FLAG_BANK0_*` constants from `gd32f10x_fmc.h`. The pre-erase `fmc_flag_clear()` from the commented-out template is intentionally omitted: `fmc_page_erase()` polls internally for completion, and `fmc_unlock()` ensures no prior operation is in progress — only a post-erase clear before `fmc_word_program()` is needed.

**Commit 2 — `ci: bump upload-artifact from v3 to v4`**

The build workflow fails immediately at job setup because `actions/upload-artifact@v3` was hard-deprecated by GitHub. v4 is a drop-in replacement. Without this fix, no CI build succeeds in this repository.

## Testing

Verified on real BurnMaster hardware running patched v1.10 firmware:
- Folder counter correctly increments on each Read ROM / Read Save operation
- Previous dumps and saves are preserved (no overwrites)
- Counter persists across power cycles

## Disclosure

Bug located and patched with assistance from Claude Code (LLM tool). All decisions and the final patch logic were reviewed against the actual GD32F10x library headers and tested on physical hardware before submission.
